### PR TITLE
Launcher3: HotseatEduController: Guard against some odd & rare NPE

### DIFF
--- a/quickstep/src/com/android/launcher3/hybridhotseat/HotseatEduController.java
+++ b/quickstep/src/com/android/launcher3/hybridhotseat/HotseatEduController.java
@@ -156,6 +156,7 @@ public class HotseatEduController {
     void showEdu() {
         int childCount = mHotseat.getShortcutsAndWidgets().getChildCount();
         CellLayout cellLayout = mLauncher.getWorkspace().getScreenWithId(Workspace.FIRST_SCREEN_ID);
+        if (cellLayout == null) return;
         // hotseat is already empty and does not require migration. show edu tip
         boolean requiresMigration = IntStream.range(0, childCount).anyMatch(i -> {
             View v = mHotseat.getShortcutsAndWidgets().getChildAt(i);


### PR DESCRIPTION
idk why it happens.
Launcher object should be init and setup, passed via constructors all the way up here. Anyways this function only tries to show a tip. Let's not crash for that.

Log:
E AndroidRuntime: FATAL EXCEPTION: main
E AndroidRuntime: Process: com.android.launcher3, PID: 4821 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.android.launcher3.CellLayout.makeSpaceForHotseatMigration(boolean)' on a null object reference E AndroidRuntime: 	at com.android.launcher3.hybridhotseat.HotseatEduController.showEdu(HotseatEduController.java:165) E AndroidRuntime: 	at com.android.launcher3.hybridhotseat.HotseatPredictionController.lambda$showEdu$3$com-android-launcher3-hybridhotseat-HotseatPredictionController(HotseatPredictionController.java:159) E AndroidRuntime: 	at com.android.launcher3.hybridhotseat.HotseatPredictionController$$ExternalSyntheticLambda3.run(Unknown Source:2) E AndroidRuntime: 	at com.android.launcher3.anim.AnimatorListeners$RunnableSuccessListener.onAnimationSuccess(AnimatorListeners.java:97) E AndroidRuntime: 	at com.android.launcher3.anim.AnimationSuccessListener.onAnimationEnd(AnimationSuccessListener.java:40) ...